### PR TITLE
Change dependabot schedule for uv ecsosystem to daily

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,6 +18,6 @@ updates:
     # Location of `uv.lock` and/or `pyproject.toml`
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
 
 


### PR DESCRIPTION
This is mostly to force a dependabot run to assess how the uv integration is working these days