### PR TITLE
Tell dependabot to ignore jinja2

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,6 +17,9 @@ updates:
   - package-ecosystem: "uv"
     # Location of `uv.lock` and/or `pyproject.toml`
     directory: "/"
+    # dependabot fails on jinja2 when using uv
+    ignore:
+      - dependency-name: "jinja2"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
When using dependabot with uv, the jinja2 updates fail: LookupError: setuptools-scm was unable to detect version for dependabot_tmp_dir

It's unclear why, but let's get the uv integration working as expected before running this down.