### PR TITLE
Tweak dependabot options

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,9 +18,9 @@ updates:
     # Location of `uv.lock` and/or `pyproject.toml`
     directory: "/"
     # dependabot fails on jinja2 when using uv
+    dependency-type:
+      - "all"
     ignore:
       - dependency-name: "jinja2"
     schedule:
       interval: "daily"
-
-


### PR DESCRIPTION
Still trying to understand why Dependabot isn't flagging package updates