### PR TITLE
Revert the dependabot config to its original state

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,9 +17,6 @@ updates:
   - package-ecosystem: "uv"
     # Location of `uv.lock` and/or `pyproject.toml`
     directory: "/"
-    allow:
-      - dependency-type: "all"
-    versioning-strategy: "lockfile-only"
     # dependabot fails on jinja2 when using uv
     ignore:
       - dependency-name: "jinja2"


### PR DESCRIPTION
The experimentation with the allow and versioning-strategy options didn't solve the problem of not receiving uv.lock PRs for package updates, so this commit removes them