### PR TITLE
Specify exact version of pyproject dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
     'pytest',
     "pytest-random-order>=1.1.1",
     'ruff',
-    "syrupy>=4.8.1",
+    "syrupy==4.8.1",
     "tomli>=2.2.1",
 ]
 docs = [


### PR DESCRIPTION
This change is to test dependabot uv behavior when there is an exact version of a package is specified in pyproject.tom and we know there's a newer version available